### PR TITLE
fix small issue in addShips()

### DIFF
--- a/client/src/game/Game.ts
+++ b/client/src/game/Game.ts
@@ -554,7 +554,7 @@ export default class Game {
       currentFuel: maxFuel ?? 32000000.0,
       maxFuel: maxFuel ?? 32000000.0,
       fuelRate: fuelRate ?? 7000.0,
-      range: 250,
+      range: range ?? 250,
       route: [],
       selected: false,
       sideColor: this.currentScenario.getSideColor(this.currentSideId),


### PR DESCRIPTION
[main] Fix small issue in addShips()

In `Game.ts` under `addShip()`, noticed that all ship's range in a Scenario file does not match the UnitDb. Found that the value "250" is hardcoded to the ship unit's range value. Supposed to be according to its weapon's max range. Fix solved small issue.